### PR TITLE
Fix USB class declaration

### DIFF
--- a/MSF_XINPUT/Teensyduino Files that were edited/hardware/teensy/avr/cores/teensy3/usb_inst.cpp
+++ b/MSF_XINPUT/Teensyduino Files that were edited/hardware/teensy/avr/cores/teensy3/usb_inst.cpp
@@ -73,7 +73,7 @@ usb_serial_class Serial;
 #endif
 
 #ifdef USB_XINPUT
-usb_xinput_class XInput;
+usb_xinput_class XInputUSB;
 usb_serial_class Serial;
 #endif
 


### PR DESCRIPTION
This was previously defined as "XInput" but used elsewhere as "XInputUSB". Seemed to work fine with optimization, but this makes the declaration consistent with other usage.